### PR TITLE
Fix: Grant access popup keeps reappearing on tab replacement

### DIFF
--- a/ttv-tools/tools.js
+++ b/ttv-tools/tools.js
@@ -5614,8 +5614,16 @@ let Initialize = async(START_OVER = false) => {
 
                         Search.authorization = `Bearer ${ oauthToken }`;
                         Search.clientID = clientID;
-                    }).catch(error => {
+                    }).catch(async error => {
                         $warn(error);
+
+                        let { oauthToken: savedToken } = await Settings.get('oauthToken');
+                        if(!nullish(savedToken) && !savedToken?.equals('.DENIED')) {
+                            Cache.save({ oauthToken: savedToken, clientID });
+                            Search.authorization = `Bearer ${ savedToken }`;
+                            Search.clientID = clientID;
+                            return;
+                        }
 
                         confirm(`<div controller
                             okay="Grant access"


### PR DESCRIPTION
Fixes #38

When the extension replaces a tab, the cache can come up empty in the new tab, causing the grant access popup to appear even after the user already authorized.

Before showing the popup, we now check `chrome.storage` for an existing token and use it directly if found — so the popup only appears when the user genuinely hasn't authorized yet.